### PR TITLE
feat: Add API route to test Supabase connection

### DIFF
--- a/npm_dev.log
+++ b/npm_dev.log
@@ -1,0 +1,14 @@
+
+> sa-vote@0.1.0 dev
+> next dev --turbopack
+
+   ▲ Next.js 15.5.2 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+   - Environments: .env.local
+
+ ✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry

--- a/src/app/api/test-supabase/route.js
+++ b/src/app/api/test-supabase/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { supabaseServer } from '@/lib/supabase/server';
+
+export async function GET() {
+  try {
+    // Perform a simple query to test the connection.
+    // We query a non-existent table to see if we get a proper response from Supabase.
+    const { data, error } = await supabaseServer.from('test_table_for_connection').select('*').limit(1);
+
+    // PostgREST error 'PGRST205' (Not Found) indicates the table doesn't exist, which is expected.
+    // This confirms the connection and authentication are working.
+    if (error && error.code !== 'PGRST205') {
+      console.error('Supabase connection test error:', error);
+      return NextResponse.json({ status: 'error', message: 'Failed to connect to Supabase.', error: error.message }, { status: 500 });
+    }
+
+    // If we get here, it means we successfully communicated with the Supabase API.
+    return NextResponse.json({ status: 'ok', message: 'Supabase connection successful.' });
+  } catch (e) {
+    console.error('Supabase connection test exception:', e);
+    return NextResponse.json({ status: 'error', message: 'An exception occurred while testing Supabase connection.', error: e.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
This commit introduces a new API route at `/api/test-supabase` to verify the server-side connection to Supabase.

The route handler attempts to query a non-existent table. If it receives a "table not found" error from Supabase (PGRST205), it confirms that the connection and authentication are working correctly. This provides a reliable way to diagnose connection issues without depending on the database schema.