### PR TITLE
修正 Supabase 伺服端客戶端載入錯誤

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -2,14 +2,33 @@
 
 import { supabaseServer } from '@/lib/supabase/server'
 import { cookies } from 'next/headers'
-import { createServerComponentClient } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 
 export async function castVoteAction(formData) {
   const electionId = formData.get('electionId')
   const candidateId = formData.get('candidateId')
 
   const cookieStore = cookies()
-  const supabase = createServerComponentClient({ cookies: () => cookieStore })
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        // 取得指定 Cookie 的值
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        // 設定或更新 Cookie
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        // 移除指定 Cookie
+        remove(name, options) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
 
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -17,11 +36,10 @@ export async function castVoteAction(formData) {
     return { error: 'You must be logged in to vote.' }
   }
 
-  // The 'cast_vote' function in the database will handle the logic
-  // of checking if the user has already voted and if the election is still active.
-  // It requires student_id, which we assume is on the user's metadata.
-  // The prompt states a trigger creates a 'users' table row from 'auth.users'.
-  // We'll assume the student_id is available in user_metadata.
+  // 資料庫中的「cast_vote」函式會處理檢查使用者是否已投票
+  // 並確認選舉是否仍在進行。此函式需要 student_id，假設存在於使用者的
+  // metadata 中。提示中提到透過觸發器由 auth.users 建立 users 資料表列，
+  // 因此我們假定 student_id 可從 user_metadata 取得。
   const { data, error } = await supabaseServer.rpc('cast_vote', {
     p_election_id: electionId,
     p_candidate_id: candidateId,
@@ -30,14 +48,14 @@ export async function castVoteAction(formData) {
 
   if (error) {
     console.error('Error casting vote:', error)
-    // Provide a more user-friendly error message
+    // 提供較為友善的錯誤訊息
     if (error.message.includes('ALREADY_VOTED')) {
-        return { error: 'You have already voted in this election.' }
+        return { error: '您已經在此選舉中投過票。' }
     }
     if (error.message.includes('ELECTION_ENDED')) {
-        return { error: 'This election has ended.' }
+        return { error: '此選舉已經結束。' }
     }
-    return { error: 'An unexpected error occurred. Please try again.' }
+    return { error: '發生預期外的錯誤，請再試一次。' }
   }
 
   return { success: 'Your vote has been cast successfully!' }

--- a/src/app/vote/page.js
+++ b/src/app/vote/page.js
@@ -1,14 +1,30 @@
 import { supabaseServer } from '@/lib/supabase/server'
 import Link from 'next/link'
 import { cookies } from 'next/headers'
-import { createServerComponentClient } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 
 export default async function VotePage() {
   const cookieStore = cookies()
-  const supabase = createServerComponentClient({ cookies: () => cookieStore }, {
-    supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
-    supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  })
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        // 取得指定 Cookie 的值
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        // 設定或更新 Cookie
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        // 移除指定 Cookie
+        remove(name, options) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
 
   const { data: { session } } = await supabase.auth.getSession()
 


### PR DESCRIPTION
## Summary
- 改用 `createServerClient` 並正確設定 Cookie 存取
- 翻譯與更新相關註解為繁體中文

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Failed to fetch Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68b995e8eefc8323b62bf7905fb31922