### PR TITLE
feat: add superadmin dashboard with election and role tools

### DIFF
--- a/src/app/admin/elections/actions.js
+++ b/src/app/admin/elections/actions.js
@@ -1,0 +1,100 @@
+'use server'
+
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+// 共用函式：建立帶有 Cookie 的 Supabase 伺服器端客戶端
+function getClient() {
+  const cookieStore = cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name, options) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
+}
+
+// 建立新的選舉
+export async function createElection(formData) {
+  const supabase = getClient()
+  const name = formData.get('name')
+  const type = formData.get('type')
+  const start_time = formData.get('start_time')
+  const end_time = formData.get('end_time')
+  const threshold = Number(formData.get('threshold'))
+
+  const { error } = await supabase.from('elections').insert({
+    name,
+    type,
+    start_time,
+    end_time,
+    threshold,
+  })
+
+  if (error) {
+    return { error: error.message }
+  }
+  return { success: true }
+}
+
+// 更新未開始的選舉
+export async function updateElection(formData) {
+  const supabase = getClient()
+  const id = formData.get('id')
+  const name = formData.get('name')
+  const type = formData.get('type')
+  const start_time = formData.get('start_time')
+  const end_time = formData.get('end_time')
+  const threshold = Number(formData.get('threshold'))
+
+  const { error } = await supabase
+    .from('elections')
+    .update({ name, type, start_time, end_time, threshold })
+    .eq('id', id)
+
+  if (error) {
+    return { error: error.message }
+  }
+  return { success: true }
+}
+
+// 新增候選人
+export async function addCandidate(formData) {
+  const supabase = getClient()
+  const election_id = formData.get('election_id')
+  const name = formData.get('name')
+
+  const { error } = await supabase.from('candidates').insert({
+    election_id,
+    name,
+  })
+
+  if (error) {
+    return { error: error.message }
+  }
+  return { success: true }
+}
+
+// 移除候選人
+export async function removeCandidate(formData) {
+  const supabase = getClient()
+  const id = formData.get('id')
+
+  const { error } = await supabase.from('candidates').delete().eq('id', id)
+
+  if (error) {
+    return { error: error.message }
+  }
+  return { success: true }
+}

--- a/src/app/admin/elections/page.tsx
+++ b/src/app/admin/elections/page.tsx
@@ -1,0 +1,88 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import React from 'react'
+import { createElection, updateElection, addCandidate, removeCandidate } from './actions'
+
+// 選舉與候選人管理頁面
+export default async function ElectionsPage() {
+  // 取得所有選舉與其候選人
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name, options) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
+
+  const { data: elections } = await supabase
+    .from('elections')
+    .select('*, candidates(*)')
+    .order('id')
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <h1 className="text-2xl font-bold">選舉管理</h1>
+      {/* 建立新選舉的表單 */}
+      <form action={createElection} className="flex flex-col gap-2 max-w-md">
+        <input name="name" placeholder="選舉名稱" className="border px-2 py-1" />
+        <input name="type" placeholder="類型" className="border px-2 py-1" />
+        <input type="datetime-local" name="start_time" className="border px-2 py-1" />
+        <input type="datetime-local" name="end_time" className="border px-2 py-1" />
+        <input name="threshold" placeholder="門檻" className="border px-2 py-1" />
+        <button type="submit" className="bg-green-600 text-white px-2 py-1">建立選舉</button>
+      </form>
+
+      {elections?.map((e) => {
+        const canEdit = e.start_time ? new Date(e.start_time) > new Date() : true
+        return (
+          <div key={e.id} className="border p-4 flex flex-col gap-2">
+            <h2 className="font-semibold">{e.name}</h2>
+            {canEdit && (
+              // 只有尚未開始的選舉可以編輯
+              <form action={updateElection} className="flex flex-col gap-2">
+                <input type="hidden" name="id" value={e.id} />
+                <input name="name" defaultValue={e.name} className="border px-2 py-1" />
+                <input name="type" defaultValue={e.type} className="border px-2 py-1" />
+                <input type="datetime-local" name="start_time" defaultValue={e.start_time?.slice(0,16)} className="border px-2 py-1" />
+                <input type="datetime-local" name="end_time" defaultValue={e.end_time?.slice(0,16)} className="border px-2 py-1" />
+                <input name="threshold" defaultValue={e.threshold} className="border px-2 py-1" />
+                <button type="submit" className="bg-blue-600 text-white px-2 py-1">更新</button>
+              </form>
+            )}
+
+            <div className="mt-2">
+              <h3 className="font-medium">候選人</h3>
+              <ul className="list-disc pl-5">
+                {e.candidates?.map((c) => (
+                  <li key={c.id} className="flex items-center gap-2">
+                    <span>{c.name}</span>
+                    <form action={removeCandidate}>
+                      <input type="hidden" name="id" value={c.id} />
+                      <button type="submit" className="text-red-600">移除</button>
+                    </form>
+                  </li>
+                ))}
+              </ul>
+              <form action={addCandidate} className="flex gap-2 mt-2">
+                <input type="hidden" name="election_id" value={e.id} />
+                <input name="name" placeholder="候選人名稱" className="border px-2 py-1" />
+                <button type="submit" className="bg-purple-600 text-white px-2 py-1">新增候選人</button>
+              </form>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/admin/electorates/actions.js
+++ b/src/app/admin/electorates/actions.js
@@ -1,0 +1,39 @@
+'use server'
+
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+// 批次匯入選舉人名冊
+export async function importElectorates(formData) {
+  const list = (formData.get('students') || '')
+    .split(/\n|,|\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((student_id) => ({ student_id }))
+
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name, options) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
+
+  const { error } = await supabase.from('electorates').insert(list)
+
+  if (error) {
+    return { error: error.message }
+  }
+  return { success: true }
+}

--- a/src/app/admin/electorates/page.tsx
+++ b/src/app/admin/electorates/page.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { importElectorates } from './actions'
+
+// 選舉人名冊管理頁面
+export default function ElectoratesPage() {
+  return (
+    <div className="p-4 max-w-lg flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">選舉人名冊管理</h1>
+      {/* 提供簡單的文字區塊供匯入使用 */}
+      <form action={importElectorates} className="flex flex-col gap-2">
+        <textarea
+          name="students"
+          placeholder="輸入學生學號，可用換行或逗號分隔"
+          className="border p-2 h-40"
+        />
+        <button type="submit" className="bg-green-600 text-white px-2 py-1">
+          匯入名單
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,40 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import React from 'react'
+
+// 管理後台的版面配置，僅允許 superadmin 進入
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  // 建立與 Supabase 的伺服器端連線，並帶入使用者的 Cookie
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name, options) {
+          cookieStore.delete({ name, ...options })
+        },
+      },
+    }
+  )
+
+  // 取得目前登入的使用者並檢查權限
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  // 若未登入或角色不是 superadmin，則拒絕存取
+  if (!user || user.app_metadata?.role !== 'superadmin') {
+    redirect('/')
+  }
+
+  return <>{children}</>
+}
+

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import React from 'react'
+
+// 管理後台首頁，提供各管理功能的入口
+export default function AdminHome() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-2xl font-bold">超級管理員後台</h1>
+      <ul className="list-disc pl-5">
+        <li>
+          <Link href="/admin/elections">選舉管理</Link>
+        </li>
+        <li>
+          <Link href="/admin/users">角色管理</Link>
+        </li>
+        <li>
+          <Link href="/admin/electorates">選舉人名冊管理</Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+
+// 角色管理頁面，可將一般使用者提升為 admin
+export default function UsersPage() {
+  const [userId, setUserId] = useState('')
+  const [role, setRole] = useState('admin')
+  const [message, setMessage] = useState('')
+
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+
+  // 呼叫 Edge Function 以更新使用者角色
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/set-user-role`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token}`,
+          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        },
+        body: JSON.stringify({ user_id: userId, role }),
+      }
+    )
+    const data = await res.json()
+    if (res.ok) {
+      setMessage('更新成功')
+    } else {
+      setMessage(data.error || '更新失敗')
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-md">
+      <h1 className="text-2xl font-bold mb-4">角色管理</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder="使用者 ID"
+          className="border px-2 py-1"
+        />
+        <select
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="admin">admin</option>
+          <option value="user">user</option>
+        </select>
+        <button type="submit" className="bg-blue-600 text-white px-2 py-1">指派角色</button>
+      </form>
+      {message && <p className="mt-2">{message}</p>}
+    </div>
+  )
+}

--- a/supabase/functions/set-user-role/index.ts
+++ b/supabase/functions/set-user-role/index.ts
@@ -1,0 +1,38 @@
+// Supabase Edge Function：設定使用者角色
+// 使用 SERVICE_ROLE_KEY 建立 Admin Client，僅供超級管理員呼叫
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+serve(async (req) => {
+  try {
+    const { user_id, role } = await req.json()
+
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SERVICE_ROLE_KEY')!,
+      {
+        auth: { autoRefreshToken: false, persistSession: false },
+      }
+    )
+
+    // 更新使用者的 app_metadata 以設定角色
+    const { error } = await supabaseAdmin.auth.admin.updateUserById(user_id, {
+      app_metadata: { role },
+    })
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 400,
+      })
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+    })
+  }
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- restrict /admin area to superadmins and add navigation
- allow superadmin to manage elections, candidates and electorates
- add user role assignment via edge function and dashboard

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a40300ac8323aaf0ecc26f635f3b